### PR TITLE
Use the ubiquitous apache.snapshots as the ID of the apache snapshots repo instead of apache-snapshots

### DIFF
--- a/virtdata-lib-curves4/pom.xml
+++ b/virtdata-lib-curves4/pom.xml
@@ -99,7 +99,7 @@
 
     <repositories>
         <repository>
-            <id>apache-snapshots</id>
+            <id>apache.snapshots</id>
             <url>http://repository.apache.org/snapshots/</url>
             <snapshots><updatePolicy>interval:60</updatePolicy></snapshots>
         </repository>


### PR DESCRIPTION
All other POMs I've seen use apache.snapshots as the ID of this repository (based on running `rg --glob '*.pom' 'apache.snapshots' ~/.m2/repository/`)  Using a different ID makes it harder to setup mirrors in `settings.xml`